### PR TITLE
Fix latency-based router starvation by decaying stale metrics

### DIFF
--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -1007,7 +1007,7 @@ class LatencyBaseRouter(RoutingInterface):
             url = endpoint.url
             if url in request_stats:
                 request_stat = request_stats[url]
-                
+
                 # 根据延迟类型选择相应的延迟指标
                 if self.latency_type == "e2e":
                     latency = request_stat.avg_latency
@@ -1015,12 +1015,19 @@ class LatencyBaseRouter(RoutingInterface):
                     latency = request_stat.avg_itl
                 else:  # ttft
                     latency = request_stat.ttft
-                
-                if latency is not None:
+
+                if latency is not None and latency >= 0:
                     if latency < best_latency:
                         best_latency = latency
                         candidate_engines = [url]
                     elif latency == best_latency:
+                        candidate_engines.append(url)
+                else:
+                    # 如果延迟信息不可用或无效，将其视为候选（延迟为0）
+                    if 0 < best_latency:
+                        best_latency = 0
+                        candidate_engines = [url]
+                    elif best_latency == 0:
                         candidate_engines.append(url)
             else:
                 # 如果没有延迟统计信息，将其视为候选（延迟为0）

--- a/src/vllm_router/stats/request_stats.py
+++ b/src/vllm_router/stats/request_stats.py
@@ -319,6 +319,8 @@ class RequestStatsMonitor(metaclass=SingletonMeta):
                 avg_dec_len = -1
 
             if engine_url in self.latency_monitors:
+                # Remove outdated latency records even if no new values arrive.
+                self.latency_monitors[engine_url].update_no_value(current_time)
                 avg_lat = self.latency_monitors[engine_url].get_average()
             else:
                 avg_lat = -1


### PR DESCRIPTION
## Summary
- decay outdated latency measurements so idle engines can recover
- treat negative latency stats as missing when selecting best engine

## Testing
- `pre-commit run --files src/vllm_router/stats/request_stats.py src/vllm_router/routers/routing_logic.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest tests/e2e/test-routing.py`

------
https://chatgpt.com/codex/tasks/task_e_68aad70959d88325a53f71f4fba67830